### PR TITLE
Trim whitepsace on moderators and error check for missing list

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,15 +15,25 @@ const Promise = require('bluebird')
 const readFile = Promise.promisify(require('fs').readFile)
 const atob = require('atob')
 
-// This gets the list from the README of the repo, from the section `Facilitators and Notetakers`
+// This gets the list from the README of the repo, from the section `Moderators and Notetakers`
 function getNewRoles (repo, lastLead) {
+  // if something messes up, blame the @ipfs-helper
+  var defaultNewRoles = { 
+    lead: '@ipfs-helper',
+    notetaker: 'TBD'
+  }
+
   return gh.repos(repo).readme.fetch()
     .then((res) => {
       var readme = atob(res.content)
       // Dumbly read from the Header to the end of the document, looking for names per line
       // Could be optimized to only look in that section
-      var facilitators = readme.substring(readme.lastIndexOf('Facilitators and Notetakers')).match(/\n- @.*/g)
-      facilitators = facilitators.map((item) => '@' + item.split('@')[1].toLowerCase())
+      var facilitators = readme.substring(readme.lastIndexOf('Moderators and Notetakers')).match(/\n- @.*/g)
+      
+      // If Moderator list in the Readme isn't up to snuff, return default 
+      if (!facilitators) return defaultNewRoles
+
+      facilitators = facilitators.map((item) => '@' + item.split('@')[1].toLowerCase().trim())
       var numFacilitators = facilitators.length
       if (facilitators.indexOf(lastLead) !== -1) {
         return {
@@ -31,26 +41,38 @@ function getNewRoles (repo, lastLead) {
           notetaker: facilitators[(facilitators.indexOf(lastLead) + 2) % numFacilitators]
         }
       } else {
-        // If you mess up, blame the @ipfs-helper
-        return {
-          lead: '@ipfs-helper',
-          notetaker: 'TBD'
-        }
+        return defaultNewRoles
       }
     })
 }
 
+// Gets the Lead from the last call.
+// Uses the call Issue from the repo, looks for first @name in the All Hands Call section
+// Assumes that gh returns the issues in inverse chronological order
 function getLastLead (repo) {
   return gh.repos(repo).issues.fetch({labels: 'calls', state: 'all'})
   .then((res) => {
     var issue = res.items[0].body
-    var lastLead = issue.substring(issue.lastIndexOf('All Hands Call')).match(/@[a-zA-Z0-9]*/g)[0]
+    var lastLeadMatch = issue.substring(issue.lastIndexOf('All Hands Call')).match(/@[a-zA-Z0-9]*/g)
+    var lastLead = (lastLeadMatch) ? lastLeadMatch[0] : 'Unknown'
     return lastLead.toLowerCase()
   }).then((lastLead) => {
     return getNewRoles(repo, lastLead)
   })
 }
 
+/**
+ * Create a github issue, substituting lookup phrases in the issue.body.  Uses environment variable NODE_GITHUB_ISSUE_BOT for github credentials.
+ * 
+ * @param {Object} issue - The issue being created.
+ * @param {string} issue.repo - The github repo (e.g., "ipfs/pm")
+ * @param {string} issue.title
+ * @param {string} issue.template - Specified as file in the repo (e.g., "templates/ipfs-all-hands.md").  
+ * "(HACKMD)" will be substituted with a link to a new hackmd.io page
+ * "LEAD" and "NOTER" will be substitued with the username of the next lead and noteaker, respectively (based on the Moderators and Notetakers section of the repo's README)  
+ * @param {array} issue.labels
+ * 
+ */
 module.exports = function createIssue (issue) {
   readFile(path.join(__dirname, issue.template), 'utf8').then((data) => {
     return hackmd(data)

--- a/templates/ipfs-all-hands.md
+++ b/templates/ipfs-all-hands.md
@@ -10,7 +10,7 @@ Zoom and Stream links will be updated directly before the calls. Links to them w
 
 Endeavour      | Lead            | Notetaker | Time (PST - UTC - CET) | Pad
 :------------: | :-------------: | :-------: | :--------------------: | :----:
-All Hands Call | LEAD   | NOTER | 9:00 **16:00** 18:00  | [agenda and notes](HACKMD)
+All Hands Call | LEAD   | NOTER | 10:00 **17:00** 19:00  | [agenda and notes](HACKMD)
 
 Please add any agenda items you have to the pad before the project-specific sprint call starts.
 


### PR DESCRIPTION
Script was failing when it could not locate the moderator list.  This
was preventing any automated issue creation.  Names were not matching
because of excess whitespace, failing to auto-assign the next
moderator/notetaker.  Added in error handling and whitespace trim.

- Added comments on functions to help anyone in the future

- Changed the time in the ipfs-all-hands template to reflect daylight
savings.

- Changed the name of the moderator list to reflect what's currently in ipfs/pm/readme.md

Resolves: #483, #586